### PR TITLE
Fix remote execution into container

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -176,7 +176,7 @@ class Client {
     command.forEach(c => path.addQuery('command', c));
     return merge({
       path    : path.toString(),
-      method  : 'GET',
+      method  : 'POST',
       headers : {
         // https://tools.ietf.org/html/rfc6455
         Connection               : 'Upgrade',


### PR DESCRIPTION
Use HTTP POST instead of HTTP GET when hitting the
`/api/v1/namespaces/${namespace}/pods/${pod}/exec` endpoint.

This aligns with `kubectl` version v1.12.2 behaviour.

Fixes #26