### PR TITLE
Support oidc authentication

### DIFF
--- a/lib/config/user.js
+++ b/lib/config/user.js
@@ -33,7 +33,7 @@ class User {
     this.token = token;
     this.password = password;
     if (typeof password == 'undefined' && typeof token === 'undefined') {
-      if (typeof authProvider !=== 'undefined' && authProvider.name === 'oidc') {
+      if (typeof authProvider !== 'undefined' && authProvider.name === 'oidc') {
         this.token = authProvider.config['id-token'];
       }      
     }

--- a/lib/config/user.js
+++ b/lib/config/user.js
@@ -9,12 +9,22 @@
  *   user:
  *     client-certificate: path/to/my/client/cert
  *     client-key: path/to/my/client/key
+ * - name: orange-user
+ *   user:
+ *     auth-provider:
+ *       name: oidc
+ *       config:
+ *          client-id: xxx
+ *          client-secret: xxx
+ *          id-token: ...idtoken...
+ *          idp-issuer-url: https://myoidcprovider.com
+ *          refresh-token: ...refreshtoken...
  */
 class User {
 
   constructor({ name, token, username, password, 'client-certificate': certificatePath,
       'client-certificate-data': certificateBase64, 'client-key': keyPath,
-      'client-key-data': keyBase64 }) {
+      'client-key-data': keyBase64, 'auth-provider': authProvider }) {
     if (typeof name === 'undefined') {
       throw Error('User name must be defined!');
     }
@@ -22,6 +32,11 @@ class User {
     this.name = name;
     this.token = token;
     this.password = password;
+    if (typeof password == 'undefined' && typeof token === 'undefined') {
+      if (typeof authProvider !=== 'undefined' && authProvider.name === 'oidc') {
+        this.token = authProvider.config['id-token'];
+      }      
+    }
     this.certificatePath = certificatePath;
     this.certificateBase64 = certificateBase64;
     this.keyPath = keyPath;


### PR DESCRIPTION
This adds basic support for OIDC authentication. It will allow people with non-expired id-tokens to authenticate to kubernetes. It does not handle automatically refreshing tokens if they are expired.