### PR TITLE
Add basic support for GCP auth

### DIFF
--- a/lib/auth/gcp.js
+++ b/lib/auth/gcp.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const { execFile } = require('child_process'),
+      { JSONPath } = require('jsonpath-plus'),
+      os           = require('os');
+class GoogleCloudPlatform {
+
+  constructor(/* User.GoogleCloudPlatformAuthProvider */ auth_provider) {
+    this.auth_provider = auth_provider;
+  }
+
+  provideAuth(options, cancellations) {
+    let promise = Promise.resolve(this.auth_provider.access_token);
+    if (this.has_token_expired()) {
+      const { promise: p, cancellation } = this.refresh_token();
+      promise = p;
+      cancellations.push(cancellation);
+    }
+    return promise.then(access_token => {
+      options.headers['Authorization'] = `Bearer ${access_token}`;
+    });
+  }
+
+  refresh_token() {
+    let promise, cancel;
+    if (os.platform() === 'browser') {
+      console.error('Refreshing GCP token in the browser is not supported! Please refresh token manually via \'gcloud container clusters get-credentials\'. ');
+      promise = Promise.resolve(this.auth_provider.access_token);
+    }
+    promise = new Promise((resolve, reject) => {
+      const process = execFile(this.auth_provider.cmd_path, this.auth_provider.cmd_args , (error, stdout, stderr) => {
+        cancel = function() {};
+        if (error) {
+          reject(error);
+        }
+        resolve(stdout);
+      });
+      cancel = function() { process.kill() };
+    });
+    promise = promise.then( response => {
+      const json = JSON.parse(response);
+      this.auth_provider.expiry = Date.parse(JSONPath(this.auth_provider.expiry_key, json)[0]);
+      this.auth_provider.access_token = JSONPath(this.auth_provider.token_key, json)[0];
+      return this.auth_provider.access_token;
+    });
+
+    return { promise, cancellation : () => cancel() };
+  }
+
+  set access_token(access_token) {
+    this.auth_provider.access_token = access_token;
+  }
+
+  get access_token() {
+    return this.auth_provider.access_token;
+  }
+
+  has_token_expired() {
+    return (this.auth_provider.expiry - Date.now()) < 5000;
+  }
+}
+
+module.exports = GoogleCloudPlatform;

--- a/lib/auth/oidc.js
+++ b/lib/auth/oidc.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const fs  = require('fs'),
-      get = require('./http-then').get,
+      get = require('../http-then').get,
       URI = require('urijs');
 
 class OpenIdConnect {
 
-  constructor(/* User.AuthProvider */ auth_provider) {
+  constructor(/* User.OpenIdConnectAuthProvider */ auth_provider) {
     this.auth_provider = auth_provider;
     this.jwt = this.auth_provider.token;
 
@@ -17,6 +17,16 @@ class OpenIdConnect {
         console.error('Reading IDP certificate authority file \'%s\' is not supported!', this.auth_provider.idp_certificate_authority);
       }
     }
+  }
+
+  provideAuth(options, cancellations) {
+    let promise = Promise.resolve(this.jwt);
+    if (this.has_token_expired()) {
+      const { promise: p, cancellation } = this.refresh_token();
+      promise = p;
+      cancellations.push(cancellation);
+    }
+    return promise.then(token => options.headers['Authorization'] = `Bearer ${token}`);
   }
 
   refresh_token() {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,9 +1,10 @@
 'use strict';
 
-const crypto        = require('crypto'),
-      get           = require('./http-then').get,
-      OpenIdConnect = require('./oidc'),
-      URI           = require('urijs');
+const crypto              = require('crypto'),
+      get                 = require('./http-then').get,
+      OpenIdConnect       = require('./auth/oidc'),
+      GoogleCloudPlatform = require('./auth/gcp'),
+      URI                 = require('urijs');
 
 class ChainRequest {
 
@@ -55,7 +56,7 @@ class ApiRequest {
 }
 
 function execute(request, { generator, readable, async, cancellable }) {
-  const { client, client: { oidc }, authorization = true, token } = request.context;
+  const { client, client: { auth_provider }, authorization = true, token } = request.context;
   const options = merge({}, client.master_api, request.options);
 
   if (!authorization) {
@@ -66,15 +67,8 @@ function execute(request, { generator, readable, async, cancellable }) {
 
   let promise = Promise.resolve();
   const cancellations = [];
-  if (oidc && authorization && !token) {
-    if (oidc.has_token_expired()) {
-      const { promise: p, cancellation } = oidc.refresh_token();
-      promise = p;
-      cancellations.push(cancellation);
-    } else {
-      promise = Promise.resolve(oidc.jwt);
-    }
-    promise = promise.then(token => options.headers['Authorization'] = `Bearer ${token}`);
+  if (auth_provider && authorization && !token) {
+    promise = auth_provider.provideAuth(options, cancellations);
   }
 
   promise = promise.then(() => {
@@ -166,9 +160,13 @@ class Client {
     this._paths = [];
     this._master_api = master_api;
     if (this.master_api.auth_provider) {
-      this.oidc = new OpenIdConnect(this.master_api.auth_provider);
+      if (this.master_api.auth_provider.name === 'oidc') {
+        this.auth_provider = new OpenIdConnect(this.master_api.auth_provider.provider);
+      } else if (this.master_api.auth_provider.name === 'gcp') {
+        this.auth_provider = new GoogleCloudPlatform(this.master_api.auth_provider.provider);
+      }
     } else {
-      delete this.oidc;
+      delete this.auth_provider;
     }
   }
 

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -1,7 +1,9 @@
-module.exports.AuthProvider = require('./user').AuthProvider;
-module.exports.Cluster      = require('./cluster');
-module.exports.Context      = require('./context');
-module.exports.Namespace    = require('./namespace');
-module.exports.User         = require('./user').User;
+module.exports.AuthProvider                    = require('./user').AuthProvider;
+module.exports.OpenIdConnectAuthProvider       = require('./user').OpenIdConnectAuthProvider;
+module.exports.GoogleCloudPlatformAuthProvider = require('./user').GoogleCloudPlatformAuthProvider;
+module.exports.Cluster                         = require('./cluster');
+module.exports.Context                         = require('./context');
+module.exports.Namespace                       = require('./namespace');
+module.exports.User                            = require('./user').User;
 
-module.exports.KubeConfig   = require('./manager');
+module.exports.KubeConfig                      = require('./manager');

--- a/lib/config/context.js
+++ b/lib/config/context.js
@@ -69,12 +69,8 @@ class Context {
     if (user.token) {
       api.headers.Authorization = `Bearer ${user.token}`;
     }
-    if (user.auth_provider && user.auth_provider.token) {
-      const auth_provider = user.auth_provider;
-      api.headers.Authorization = `Bearer ${auth_provider.token}`;
-      if (auth_provider.refresh_token && auth_provider.url && auth_provider.client_id && auth_provider.client_secret) {
-        api.auth_provider = auth_provider;
-      }
+    if (user.auth_provider) {
+      api.auth_provider = user.auth_provider;
     }
     if (cluster.rejectUnauthorized) {
       api.rejectUnauthorized = false;

--- a/lib/config/user.js
+++ b/lib/config/user.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {isNotEmpty} = require('../util');
+
 /**
  * users:
  * - name: blue-user
@@ -14,11 +16,11 @@
  *     auth-provider:
  *       name: oidc
  *       config:
- *          client-id: xxx
- *          client-secret: xxx
- *          id-token: ...idtoken...
- *          idp-issuer-url: https://myoidcprovider.com
- *          refresh-token: ...refreshtoken...
+ *         client-id: xxx
+ *         client-secret: xxx
+ *         id-token: ...idtoken...
+ *         idp-issuer-url: https://myoidcprovider.com
+ *         refresh-token: ...refreshtoken...
  */
 class User {
 
@@ -29,7 +31,7 @@ class User {
       throw Error('User name must be defined!');
     }
     if (typeof auth_provider !== 'undefined') {
-      this.auth_provider = new AuthProvider(Object.assign({ name: auth_provider.name }, auth_provider.config));
+      this.auth_provider = new AuthProvider(Object.assign({ name: auth_provider.name, config: auth_provider.config }));
     }
     this.name = name;
     this.token = token;
@@ -48,11 +50,36 @@ class User {
 
 class AuthProvider {
 
-  constructor({ name, 'idp-issuer-url': url, 'id-token': token, 'refresh-token': refresh_token,
+  constructor({ name, config}) {
+    this.name = name;
+    // TODO: add support for others e.g azure, openstack
+    if (name === 'oidc') {
+      this.provider = new OpenIdConnectAuthProvider(config);
+    } else if ( name === 'gcp') {
+      this.provider = new GoogleCloudPlatformAuthProvider(config);
+    }
+  }
+
+  get token() {
+    return this.provider.token;
+  }
+}
+
+/**
+ * auth-provider:
+ * name: oidc
+ * config:
+ *   client-id: xxx
+ *   client-secret: xxx
+ *   id-token: ...idtoken...
+ *   idp-issuer-url: https://myoidcprovider.com
+ *   refresh-token: ...refreshtoken...
+ */
+class OpenIdConnectAuthProvider {
+  constructor({ 'idp-issuer-url': url, 'id-token': token, 'refresh-token': refresh_token,
       'client-id': client_id, 'client-secret': client_secret, 'idp-certificate-authority': ca }) {
     this.client_id = client_id;
     this.client_secret = client_secret;
-    this.name = name;
     this.token = token;
     this.refresh_token = refresh_token;
     if (url && url.endsWith('/')) {
@@ -61,6 +88,39 @@ class AuthProvider {
       this.url = url;
     }
     this.idp_certificate_authority = ca;
+  }  
+}
+
+ // TODO: support scopes and different time formats
+class GoogleCloudPlatformAuthProvider {
+  constructor({ 'scopes': scopes, 'access-token': access_token, 'expiry': expiry,
+      'cmd-path': cmd_path, 'cmd-args': cmd_args, 'token-key': token_key, 'expiry-key': expiry_key, 'time-fmt': time_fmt}) {
+    this.scopes = scopes;
+    this.access_token = access_token;
+    this.expiry = expiry === 'undefined' ? Date.now() : Date.parse(expiry);
+    this.cmd_path = cmd_path;
+    this.cmd_args = isNotEmpty(cmd_args) ? cmd_args.split(' ') : cmd_args;
+    if (isNotEmpty(token_key)) {
+      // let's convert Golang's JSONPath to NodeJS's jsonpath-plus
+      if (token_key.charAt(0) === '{' && token_key.charAt(token_key.length -1) === '}') {
+        this.token_key = '$' + token_key.substring(1, token_key.length - 1)
+      } else {
+        this.token_key = token_key;
+      }
+    }
+    if (isNotEmpty(expiry_key)) {
+      // let's convert Golang's JSONPath to NodeJS's jsonpath-plus
+      if (expiry_key.charAt(0) === '{' && expiry_key.charAt(expiry_key.length -1) === '}') {
+        this.expiry_key = '$' + expiry_key.substring(1, expiry_key.length - 1)
+      } else {
+        this.expiry_key = expiry_key;
+      }
+    }
+    this.time_fmt = time_fmt; // defaults to Golang's RFC3339Nano https://golang.org/pkg/time/
+  }
+
+  get token() {
+    return this.access_token;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "blessed": "~0.1.81",
     "bresenham": "0.0.4",
     "clipboardy": "~1.2.3",
+    "jsonpath-plus": "~0.20.1",
     "js-yaml": "3.13.1",
     "gl-matrix": "2.1.0",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
This adds basic support for kubebox to authenticate via Google Cloud Platform (GCP) #50  
I've changed the way authentication was implemented. Now providers are called and can modify outgoing HTTP request through the provideAuth method. This should make it easier to add other providers in the future.

This PR still has some limitations:

- Scopes aren't supported
- Browser not supported (command has to be run locally). 
- Time format isn't taken into account and relies solely on Javascript's Date parser.

Thanks!