### PR TITLE
Fix crash in lib/ui/blessed-xterm/blessed-xterm.js when m1 or m2 is undefined in _selection

### DIFF
--- a/lib/ui/blessed-xterm/blessed-xterm.js
+++ b/lib/ui/blessed-xterm/blessed-xterm.js
@@ -229,6 +229,14 @@ class XTerm extends blessed.ScrollableBox {
     const yl = ret.yl - this.ibottom;
 
     // selection
+    if (this._selection) {
+      if (this._selection.m1 === undefined) {
+        this._selection.m1 = {};
+      }
+      if (this._selection.m2 === undefined) {
+        this._selection.m2 = {};
+      }
+    }
     let { x1: xs1, x2: xs2, m1: { line: ys1 }, m2: { line: ys2 } } = this._selection || { m1: {}, m2: {} };
     if (this._selection) {
       // back to wrapped lines coordinates


### PR DESCRIPTION
If `this._selection` is defined but `this._selection.m1` or `this._selection.m2` is undefined, it will crash on line 232 of `lib/ui/blessed-xterm/blessed-xterm.js`.

I found this issue when I was trying to use `lib/ui/blessed-xterm/blessed-xterm.js` in my own project when I drag mouse from one blessed screen to an adjacent blessed screen.

I don't know whether you have such case in kubebox, but from the code logic, we can't assume `m1` and `m2`  are defined when `this._selection` is defined.