### PR TITLE
add tab/shift tab to toggle between pods/logs and more ...

### DIFF
--- a/lib/ui/dashboard.js
+++ b/lib/ui/dashboard.js
@@ -786,8 +786,7 @@ class Dashboard {
 }
 
 function setupToggle (screen, debug, validElements) {
-  validElements.forEach(validElement => {
-    let element = getElementWithLabel(validElement.options.label);
+  validElements.forEach(element => {
     if (element) {
       element.on('focus', () => {
         element.style.border.fg = 'red';
@@ -797,27 +796,22 @@ function setupToggle (screen, debug, validElements) {
         element.style.border.fg = "white";
       });
     }
-  })
+  });
 
   screen.key(['tab', 'S-tab'], function (_, key) {
-    let currentIndex = getIndexOfFocused()
+    let currentIndex = getIndexOfFocused();
     if (currentIndex >= 0) {
-      let nextIndex = getNextIndex(currentIndex, validElements.length - 1, (key.shift && key.name === 'tab') ? -1 : 1)
-      let target = getElementWithLabel(validElements[nextIndex].options.label)
-      if (target) target.focus();
+      let nextIndex = getNextIndex(currentIndex, validElements.length - 1, (key.shift && key.name === 'tab') ? -1 : 1);
+      validElements[nextIndex].focus();
     }
   });
   
   function getIndexOfFocused() {
     const focused = screen.children.find(element => element.focused);
     for (let i = 0; i < validElements.length; i ++) {
-      if (validElements[i].options.label === focused.options.label) return i;
+      if (validElements[i] === focused) return i;
     }
     return -1;
-  }
-
-  function getElementWithLabel(label) {
-    return screen.children.find(element => element.options.label === label);
   }
 
   function getNextIndex(currentIndex, maxIndex, increment) {

--- a/lib/ui/dashboard.js
+++ b/lib/ui/dashboard.js
@@ -810,9 +810,6 @@ function setupToggle (screen, debug) {
   }
 
   screen.children.forEach(element => {
-    debug.log(Object.entries(element))
-    console.log("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-    console.dir(element)
     const label = element.options.label;
     if (!validElementValues.includes(label)) return;
     

--- a/lib/ui/dashboard.js
+++ b/lib/ui/dashboard.js
@@ -785,9 +785,9 @@ class Dashboard {
   }
 }
 
-function setupToggle (screen, debug, validElementValues) {
-  validElementValues.forEach( vE => {
-    let element = getElementWithLabel(vE.options.label);
+function setupToggle (screen, debug, validElements) {
+  validElements.forEach(validElement => {
+    let element = getElementWithLabel(validElement.options.label);
     if (element) {
       element.on('focus', () => {
         element.style.border.fg = 'red';
@@ -799,29 +799,19 @@ function setupToggle (screen, debug, validElementValues) {
     }
   })
 
-  // screen.children.forEach(element => {
-  //   const childLabel = element.options.label;
-  //   validElementValues.find(e => e.options.l)
-
-  //   validElementValues.forEach(element => {
-  //     if (element.options.label === childLabel ) {
-  //     }
-  //   })
-  // });
-
   screen.key(['tab', 'S-tab'], function (_, key) {
     let currentIndex = getIndexOfFocused()
     if (currentIndex >= 0) {
-      let nextIndex = getNextIndex(currentIndex, validElementValues.length - 1, (key.shift && key.name === 'tab') ? -1 : 1)
-      let target = getElementWithLabel(validElementValues[nextIndex].options.label)
+      let nextIndex = getNextIndex(currentIndex, validElements.length - 1, (key.shift && key.name === 'tab') ? -1 : 1)
+      let target = getElementWithLabel(validElements[nextIndex].options.label)
       if (target) target.focus();
     }
   });
   
   function getIndexOfFocused() {
     const focused = screen.children.find(element => element.focused);
-    for (let i = 0; i < validElementValues.length; i ++) {
-      if (validElementValues[i].options.label === focused.options.label) return i;
+    for (let i = 0; i < validElements.length; i ++) {
+      if (validElements[i].options.label === focused.options.label) return i;
     }
     return -1;
   }

--- a/lib/ui/dashboard.js
+++ b/lib/ui/dashboard.js
@@ -807,11 +807,7 @@ function setupToggle (screen, debug, validElements) {
   });
   
   function getIndexOfFocused() {
-    const focused = screen.children.find(element => element.focused);
-    for (let i = 0; i < validElements.length; i ++) {
-      if (validElements[i] === focused) return i;
-    }
-    return -1;
+    return validElements.indexOf(validElements.find(element => element.focused));
   }
 
   function getNextIndex(currentIndex, maxIndex, increment) {

--- a/lib/ui/dashboard.js
+++ b/lib/ui/dashboard.js
@@ -779,7 +779,47 @@ class Dashboard {
       updatePodsTable();
       screen.render();
     }
+
+    setupToggle(screen, debug);
   }
+}
+
+function setupToggle (screen, debug) {
+  const validElementValues = Object.values({
+    logs: "Logs",
+    pods: "Pods",
+  });
+
+  screen.key(['tab', 'S-tab'], function (_, key) {
+    const focused = screen.children.find(element => element.focused);
+    let currentIndex = validElementValues.indexOf(focused.options.label)
+    let nextIndex = getNextIndex(currentIndex, validElementValues.length - 1, (key.shift && key.name === 'tab') ? -1 : 1)
+    let target = getElementWithLabel(validElementValues[nextIndex])
+    
+    if (target) target.focus();
+  });
+  
+  function getElementWithLabel(label) {
+    return screen.children.find(element => element.options.label === label);
+  }
+
+  function getNextIndex(currentIndex, maxIndex, increment) {
+    let nextIndex = currentIndex + increment;
+    return (nextIndex < 0) ? maxIndex : (nextIndex > maxIndex) ? 0 : nextIndex;
+  }
+
+  screen.children.forEach(element => {
+    const label = element.options.label;
+    if (!validElementValues.includes(label)) return;
+    
+    element.on('focus', () => {
+      element.style.border.fg = 'red';
+    });
+    element.on('blur', () => {
+      element.set("selected", false);
+      element.style.border.fg = "white";
+    });
+  });
 }
 
 function containerLogsLabel(pod, container, { tag, style } = {}) {

--- a/lib/ui/dashboard.js
+++ b/lib/ui/dashboard.js
@@ -795,14 +795,13 @@ function setupToggle (screen, debug, validElements) {
         element.set("selected", false);
         element.style.border.fg = "white";
       });
-    }
-  });
-
-  screen.key(['tab', 'S-tab'], function (_, key) {
-    let currentIndex = getIndexOfFocused();
-    if (currentIndex >= 0) {
-      let nextIndex = getNextIndex(currentIndex, validElements.length - 1, (key.shift && key.name === 'tab') ? -1 : 1);
-      validElements[nextIndex].focus();
+      element.key(['tab', 'S-tab'], function (_, key) {
+        let currentIndex = getIndexOfFocused();
+        if (currentIndex >= 0) {
+          let nextIndex = getNextIndex(currentIndex, validElements.length - 1, (key.shift && key.name === 'tab') ? -1 : 1);
+          validElements[nextIndex].focus();
+        }
+      });
     }
   });
   

--- a/lib/ui/dashboard.js
+++ b/lib/ui/dashboard.js
@@ -781,25 +781,51 @@ class Dashboard {
       screen.render();
     }
 
-    setupToggle(screen, debug);
+    setupToggle(screen, debug, [pods_table, pod_log]);
   }
 }
 
-function setupToggle (screen, debug) {
-  const validElementValues = Object.values({
-    logs: "Logs",
-    pods: "Pods",
-  });
+function setupToggle (screen, debug, validElementValues) {
+  validElementValues.forEach( vE => {
+    let element = getElementWithLabel(vE.options.label);
+    if (element) {
+      element.on('focus', () => {
+        element.style.border.fg = 'red';
+      });
+      element.on('blur', () => {
+        element.set("selected", false);
+        element.style.border.fg = "white";
+      });
+    }
+  })
+
+  // screen.children.forEach(element => {
+  //   const childLabel = element.options.label;
+  //   validElementValues.find(e => e.options.l)
+
+  //   validElementValues.forEach(element => {
+  //     if (element.options.label === childLabel ) {
+  //     }
+  //   })
+  // });
 
   screen.key(['tab', 'S-tab'], function (_, key) {
-    const focused = screen.children.find(element => element.focused);
-    let currentIndex = validElementValues.indexOf(focused.options.label)
-    let nextIndex = getNextIndex(currentIndex, validElementValues.length - 1, (key.shift && key.name === 'tab') ? -1 : 1)
-    let target = getElementWithLabel(validElementValues[nextIndex])
-    
-    if (target) target.focus();
+    let currentIndex = getIndexOfFocused()
+    if (currentIndex >= 0) {
+      let nextIndex = getNextIndex(currentIndex, validElementValues.length - 1, (key.shift && key.name === 'tab') ? -1 : 1)
+      let target = getElementWithLabel(validElementValues[nextIndex].options.label)
+      if (target) target.focus();
+    }
   });
   
+  function getIndexOfFocused() {
+    const focused = screen.children.find(element => element.focused);
+    for (let i = 0; i < validElementValues.length; i ++) {
+      if (validElementValues[i].options.label === focused.options.label) return i;
+    }
+    return -1;
+  }
+
   function getElementWithLabel(label) {
     return screen.children.find(element => element.options.label === label);
   }
@@ -808,19 +834,6 @@ function setupToggle (screen, debug) {
     let nextIndex = currentIndex + increment;
     return (nextIndex < 0) ? maxIndex : (nextIndex > maxIndex) ? 0 : nextIndex;
   }
-
-  screen.children.forEach(element => {
-    const label = element.options.label;
-    if (!validElementValues.includes(label)) return;
-    
-    element.on('focus', () => {
-      element.style.border.fg = 'red';
-    });
-    element.on('blur', () => {
-      element.set("selected", false);
-      element.style.border.fg = "white";
-    });
-  });
 }
 
 function containerLogsLabel(pod, container, { tag, style } = {}) {

--- a/lib/ui/dashboard.js
+++ b/lib/ui/dashboard.js
@@ -133,6 +133,7 @@ class Dashboard {
     graphs.slice(1).forEach(g => g.toggle());
 
     const pod_log = blessed.log({
+      parent : screen,
       label  : 'Logs',
       top    : '50%',
       bottom : '1',
@@ -809,6 +810,9 @@ function setupToggle (screen, debug) {
   }
 
   screen.children.forEach(element => {
+    debug.log(Object.entries(element))
+    console.log("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+    console.dir(element)
     const label = element.options.label;
     if (!validElementValues.includes(label)) return;
     


### PR DESCRIPTION
Hello,

based on this pull request #80 i found a solution for my issue #98.

The benefit of this solution is that the screen.key ... function only gets bind once and the code gets only executed once. 
In #80 I've seen that the code from screen.key... is executed multiple times after switching between dashboard and debug view.

Kind regards
Frank