### PR TITLE
Add undefined check for NodeJD TLS certifactes before using them

### DIFF
--- a/lib/config/context.js
+++ b/lib/config/context.js
@@ -93,7 +93,11 @@ class Context {
       }
     }
     if (ca) {
-      api.ca = tls.rootCertificates.concat([ca]);
+      if (tls.rootCertificates) {
+        api.ca = tls.rootCertificates.concat([ca]);
+      } else {
+        api.ca = [ca]
+      }
     }
     return api;
   }


### PR DESCRIPTION
Was getting 

```
TypeError: Cannot read property 'concat' of undefined
    at Context.getMasterApi (/home/jpoth/dev/git/kubik/lib/config/context.js:96:37)
    at new Kubebox (/home/jpoth/dev/git/kubik/lib/kubebox.js:41:57)
    at Object.<anonymous> (/home/jpoth/dev/git/kubik/index.js:68:1)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Function.Module.runMain (module.js:694:10)
    at startup (bootstrap_node.js:204:16)

```

Thanks !
